### PR TITLE
use custom identity paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/drone/drone/pkg/build/log"
+	"github.com/drone/drone/shared/build/log"
 )
 
 type SshConfigFileSection struct {

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/drone/drone/shared/build/log"
+	log "github.com/Sirupsen/logrus"
 )
 
 type SshConfigFileSection struct {

--- a/ssh.go
+++ b/ssh.go
@@ -173,7 +173,7 @@ func sshAgentConfig(userName string, a agent.Agent) (*ssh.ClientConfig, error) {
 
 // sshDefaultConfig returns the SSH client config for the connection
 func sshDefaultConfig(userName, identity string) (*ssh.ClientConfig, error) {
-	contents, err := loadDefaultIdentity(userName, identity)
+	contents, err := loadIdentity(userName, identity)
 	if err != nil {
 		return nil, err
 	}
@@ -190,12 +190,15 @@ func sshDefaultConfig(userName, identity string) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-// loadDefaultIdentity returns the private key file's contents
-func loadDefaultIdentity(userName, identity string) ([]byte, error) {
-	u, err := user.Current()
-	if err != nil {
-		return nil, err
+// loadIdentity returns the private key file's contents
+func loadIdentity(userName, identity string) ([]byte, error) {
+	if filepath.Dir(identity) == "." {
+		u, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+		identity = filepath.Join(u.HomeDir, ".ssh", identity)
 	}
 
-	return ioutil.ReadFile(filepath.Join(u.HomeDir, ".ssh", identity))
+	return ioutil.ReadFile(identity)
 }


### PR DESCRIPTION
This fixes the upstream import for `github.com/drone/drone/shared/build/log` and enables custom paths (i.e. identity files not in the home `.ssh` directory).

For example, `slex -u foo -i /home/user/keys/custom_id_rsa --host 1.2.3.4`.