### PR TITLE
Add username to log output for each executed command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func runSSH(c command, host string, section *SshConfigFileSection, agentForwardi
 	}
 	defer func() {
 		session.Close()
-		log.Printf("Session complete from %s", host)
+		log.Printf("Session complete from %s@%s", section.User, host)
 	}()
 
 	for key, value := range c.Env {


### PR DESCRIPTION
This pull request contains a really small change which only adds the the SSH username to the log output (where username and host are separated by the `@` symbol). The actual `username` value is the one parsed from the `User` ssh-config directive. This way it's easier to spot under which user the command was actually executed on the remote host (without consulting the `~/.ssh/config` file).

An example run would now look like (where `username` would be the value of the `User` directive for a host called `example.org` in the `~/.ssh/config` file):
```
$ ./slex --host example.org --agent uptime
INFO[0000] Session complete from username@example.org:22
 17:34:09 up 183 days, 47 min,  2 users,  load average: 2.59, 2.71, 2.72 
```