### PR TITLE
change grabbing user from section to config

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func runSSH(c command, host string, section *SshConfigFileSection, agentForwardi
 	}
 	defer func() {
 		session.Close()
-		log.Printf("Session complete from %s@%s", section.User, host)
+		log.Printf("Session complete from %s@%s", config.User, host)
 	}()
 
 	for key, value := range c.Env {


### PR DESCRIPTION
Previously would throw if there was no corresponding ssh config (reading `User` off non-existent `section`).

Changed to read `User` from the parsed config.

###### Reproduce

``` sh
$ cat $HOME/.ssh/config
# I'm a glutton for punishment and haven't configured my hosts!

$ slex --host some.cool.ip.address --user internetchampion42 uptime
```

*EDIT*: I'm pretty nubby when it comes to Go. This was my interpretation of the error and making this change fixed it. ¯\\_(ツ)_/¯