### PR TITLE
Support official OpenSSH client option format

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -71,4 +72,21 @@ func parseSSHConfigFile(path string) (map[string]*SSHConfigFileSection, error) {
 	}
 
 	return sections, nil
+}
+
+// ParseOptions converts a list of OpenSSH client options to key-value pairs.
+// Each option in the list is a keyword-argument pair which is
+// either separated by whitespace or optional whitespace and exactly one '='.
+// For the full list of options, see man 5 ssh_config.
+func ParseOptions(plainOpts []string) map[string]string {
+	optionExpr := regexp.MustCompile("(\\w+)\\s*=?\\s*(.+)")
+	options := make(map[string]string)
+
+	for _, i := range plainOpts {
+		m := optionExpr.FindStringSubmatch(i)
+		options[m[1]] = m[2]
+	}
+
+	log.Debugf("parsed SSH options: %v", options)
+	return options
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseOptions(t *testing.T) {
+	verify := func(fmt string, exp map[string]string, out map[string]string) {
+		if len(out) != len(exp) {
+			t.Errorf("Some options are not parsed - format: %s, expected: %q, output: %q.", fmt, exp, out)
+		}
+		for k, v := range exp {
+			o := out[k]
+			if o != v {
+				t.Errorf("Could not parse option - format: %s, expected: '%s: %s', output: '%s: %s'.", fmt, k, v, k, o)
+			}
+		}
+	}
+
+	// Test option pattern '<keyword> <argument>'
+	{
+		fmt := "<keyword> <argument>"
+		in := []string{"Host 127.0.0.1", "Port 22"}
+		exp := map[string]string{"Host": "127.0.0.1", "Port": "22"}
+		out := ParseOptions(in)
+
+		verify(fmt, exp, out)
+	}
+
+	// Test option pattern '<keyword>=<argument>'
+	{
+		fmt := "<keyword>=<argument>"
+		in := []string{"Host=127.0.0.1", "Port=22"}
+		exp := map[string]string{"Host": "127.0.0.1", "Port": "22"}
+		out := ParseOptions(in)
+
+		verify(fmt, exp, out)
+	}
+
+	// Test option pattern '<keyword> = <argument>'
+	{
+		fmt := "<keyword> = <argument>"
+		in := []string{"Host = 127.0.0.1", "Port = 22"}
+		exp := map[string]string{"Host": "127.0.0.1", "Port": "22"}
+		out := ParseOptions(in)
+
+		verify(fmt, exp, out)
+	}
+
+	// Test option pattern '<keyword><tab><argument>'
+	{
+		fmt := "<keyword><tab><argument>"
+		in := []string{"Host	127.0.0.1", "Port	22"}
+		exp := map[string]string{"Host": "127.0.0.1", "Port": "22"}
+		out := ParseOptions(in)
+
+		verify(fmt, exp, out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -45,19 +45,6 @@ func loadHosts(context *cli.Context) ([]string, error) {
 	return hosts, nil
 }
 
-// getOptions returns the SSH client options given on the command line.
-func getOptions(context *cli.Context) map[string]string {
-	options := make(map[string]string)
-
-	ins := []string(context.GlobalStringSlice("option"))
-	for _, i := range ins {
-		pair := strings.SplitN(i, " ", 2)
-		options[pair[0]] = pair[1]
-	}
-
-	return options
-}
-
 // multiplexAction uses the arguments passed via the command line and
 // multiplexes them across multiple SSH connections
 func multiplexAction(context *cli.Context) error {
@@ -97,7 +84,8 @@ func multiplexAction(context *cli.Context) error {
 	}
 	methods := defaultAuthMethods(c.User, identity, agt)
 
-	options := getOptions(context)
+	plainOptions := []string(context.GlobalStringSlice("option"))
+	options := ParseOptions(plainOptions)
 
 	quiet := context.GlobalBool("quiet")
 	group := &sync.WaitGroup{}


### PR DESCRIPTION
According to man 5 ssh_config, the client option may be separated
by whitespace or optional whitespace and exactly one ‘=’.

Close #17 