### PR TITLE
Use os.user's HomeDir instead of env variable.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -47,15 +50,21 @@ func parseSSHConfigFileSection(content string) *SSHConfigFileSection {
 }
 
 // parseSSHConfigFile parses the ~/.ssh/config file and build a list of section
-func parseSSHConfigFile(path string) (map[string]*SSHConfigFileSection, error) {
+func parseSSHConfigFile() (map[string]*SSHConfigFileSection, error) {
 
 	sections := make(map[string]*SSHConfigFileSection)
 
-	log.Debugf("parsing ssh config file: %s", path)
-	content, err := ioutil.ReadFile(path)
+	user, err := user.Current()
+	if err != nil {
+		return sections, err
+	}
+	conf := filepath.Join(user.HomeDir, ".ssh", "config")
+
+	log.Debugf("parsing ssh config file: %s", conf)
+	content, err := ioutil.ReadFile(conf)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Debugf("cannot find ssh config file: %s", path)
+			log.Debugf("cannot find ssh config file: %s", conf)
 			return sections, nil
 		}
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -19,34 +18,6 @@ type SSHConfigFileSection struct {
 	HostName     string
 	Port         string
 	IdentityFile string
-}
-
-// parseSSHConfigFileSection parses a section from the ~/.ssh/config file
-func parseSSHConfigFileSection(content string) *SSHConfigFileSection {
-	section := &SSHConfigFileSection{}
-
-	for n, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		if n == 0 {
-			section.Host = line
-		} else if strings.HasPrefix(line, "ForwardAgent") {
-			section.ForwardAgent = strings.TrimSpace(strings.TrimPrefix(line, "ForwardAgent"))
-		} else if strings.HasPrefix(line, "User") {
-			section.User = strings.TrimSpace(strings.TrimPrefix(line, "User"))
-		} else if strings.HasPrefix(line, "HostName") {
-			section.HostName = strings.TrimSpace(strings.TrimPrefix(line, "HostName"))
-		} else if strings.HasPrefix(line, "Port") {
-			section.Port = strings.TrimSpace(strings.TrimPrefix(line, "Port"))
-		} else if strings.HasPrefix(line, "IdentityFile") {
-			section.IdentityFile = strings.TrimSpace(strings.TrimPrefix(line, "IdentityFile"))
-		}
-	}
-	log.Debugf("parsed ssh config file section: %s", section.Host)
-	return section
 }
 
 // parseSSHConfigFile parses the ~/.ssh/config file and build a list of section
@@ -69,15 +40,34 @@ func parseSSHConfigFile() (map[string]*SSHConfigFileSection, error) {
 		}
 		return nil, err
 	}
-
-	for _, split := range strings.Split(string(content), "Host ") {
-		split = strings.TrimSpace(split)
-		if split == "" {
+	lines := strings.Split(string(content), "\n")
+	current := &SSHConfigFileSection{}
+	for _, line := range lines {
+		parts := strings.SplitN(strings.TrimSpace(line), " ", 2)
+		if len(parts) != 2 {
 			continue
 		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+		if key == "host" {
+			if current.Host != "" {
+				sections[current.Host] = current
+			}
+			current = &SSHConfigFileSection{Host: val}
+		} else if key == "hostname" {
+			current.HostName = val
+		} else if key == "user" {
+			current.User = val
+		} else if key == "port" {
+			current.Port = val
+		} else if key == "forwardagent" {
+			current.ForwardAgent = val
+		}
+	}
 
-		section := parseSSHConfigFileSection(split)
-		sections[section.Host] = section
+	// add last host to map
+	if current.Host != "" {
+		sections[current.Host] = current
 	}
 
 	return sections, nil

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -59,7 +58,7 @@ func multiplexAction(context *cli.Context) error {
 		return err
 	}
 
-	sections, err := parseSSHConfigFile(filepath.Join(os.Getenv("HOME"), ".ssh", "config"))
+	sections, err := parseSSHConfigFile()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This should help better support different environments.

Config parsing now works with more valid ssh config files -- the keys are case-insensitive, but the original version required capitalized, camel-cased keys.