### PR TITLE
add default HostKeyCallback to SSH client config

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -72,6 +72,9 @@ func newSSHClientConfig(user, host string, agt agent.Agent, method ssh.AuthMetho
 	config := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{method},
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
 	}
 	return &sshClientConfig{
 		agent:        agt,


### PR DESCRIPTION
I noticed the following issue when compiling `slex` with go version go1.9.2 darwin/amd64:

```
ssh: must specify HostKeyCallback
```

This is related to this issue: https://github.com/golang/go/issues/19767

This change should keep the code compatible with older versions of go.
