### PR TITLE
fix: `go get -d` does not install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration files if you do not want to.
 To build `slex` you must have a working Go install then you can run:
 
 ```bash
-go get -d github.com/crosbymichael/slex
+go get -u github.com/crosbymichael/slex
 ```
 
 ```bash


### PR DESCRIPTION
The `-d` flag does not actually install the binary so unable to call `slex` afterwards. The `-u` flag will update from the internet and also install.